### PR TITLE
Unicode error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-CCScript 1.337 (LEGACY)
+CCScript 1.401
 =======================
 
 This is the older, crappier version of CCScript, last updated Auguest 24, 2009.
-This version is no longer maintained; this repository exists mainly for easy
-reference in the development of CCScript 2, but also to track some minor tweaks
-to CCScript 1.3's build system and code so that it can actually be compiled on
-non-Windows platforms.
+This version is not frequently maintained; this repository exists mainly for
+easy reference in the development of CCScript 2, but also to track some minor
+tweaks to CCScript 1's build system and code so that it can actually be
+compiled on non-Windows platforms.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if platform.system() == "Linux" or platform.system() == "Darwin":
     extra_compile_args = ["-std=c++11"]
 
 setup(name="ccscript",
-    version="1.339",
+    version="1.401",
     description="ccscript",
     url="http://starmen.net/pkhack/ccscript",
     ext_modules=[

--- a/src/ccc.cpp
+++ b/src/ccc.cpp
@@ -42,7 +42,7 @@ string getbasepath(const char* p)
 
 void printversion()
 {
-	cout << "ccc version 1.339 Duck Tape Edition" << endl;
+	cout << "ccc version 1.401 Duck Tape Edition" << endl;
 }
 
 void printusage()

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -349,7 +349,9 @@ symbol Lexer::LexSymbol()
 				return LexNumber();
 			}
 			else {
-				Error(string("unexpected character '") + current + "'");
+				char buf[8];
+				snprintf(buf, 8, "%02X", (unsigned int)(current & 0xFF));
+				Error(string("unexpected character 0x") + buf);
 				Next();
 				continue;
 			}


### PR DESCRIPTION
This PR fixes an issue where invalid UTF-8 sequences will be written into the CCC compiler output, causing CoilSnake to raise a UnicodeError during compilation instead of displaying the error message from CCScript compilation.